### PR TITLE
ODP-991: Fix phoenix-queryserver/bin/daemon.py for python3 support

### DIFF
--- a/phoenix-queryserver/bin/daemon.py
+++ b/phoenix-queryserver/bin/daemon.py
@@ -727,9 +727,9 @@ def is_socket(fd):
         """
     result = False
 
-    file_socket = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
 
     try:
+        file_socket = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
         socket_type = file_socket.getsockopt(
                 socket.SOL_SOCKET, socket.SO_TYPE)
     except socket.error as exc:


### PR DESCRIPTION
ODP-991: Fix phoenix-queryserver/bin/daemon.py for python3 support

Tested in ITI cluster