### PR TITLE
ODP-3789: Fixing hbase-shaded-jersey java mismatch error by excluding this jar.

### DIFF
--- a/phoenix-connectors/pom.xml
+++ b/phoenix-connectors/pom.xml
@@ -667,7 +667,13 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
-        <version>${hbase.version}</version>
+       <version>${hbase.version}</version>
+       <exclusions>
+          <exclusion>
+            <groupId>org.apache.hbase.thirdparty</groupId>
+            <artifactId>hbase-shaded-jersey</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
This patch was tested locally.